### PR TITLE
Update Ubuntu image version to 22.04 in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
 jobs:
   test_talent:
     machine:
-      image: ubuntu-2004:2022.10.1
+      image: ubuntu-2204:2022.04.2
     working_directory: ~/talent
     steps:
       - checkout
@@ -42,7 +42,7 @@ jobs:
             make ci-test
   push_service_image:
     machine:
-      image: ubuntu-2004:2022.10.1
+      image: ubuntu-2204:2022.04.2
     working_directory: ~/talent
     steps:
       - checkout
@@ -56,7 +56,7 @@ jobs:
             docker-push -f deploy/build.config
   deploy_service_cloud_run:
     machine:
-      image: ubuntu-2004:2022.10.1
+      image: ubuntu-2204:2022.04.2
     parameters:
       environment:
         description: "The environment where to deploy the application"


### PR DESCRIPTION
Changed the Ubuntu image version from 20.04 to 22.04 in the CircleCI configuration
file for consistency and compatibility with other services.