### PR TITLE
Adjust max-height for images in richtext class

### DIFF
--- a/app/blog/static/css/blog/common.css
+++ b/app/blog/static/css/blog/common.css
@@ -6,6 +6,7 @@
 .richtext img {
 	max-width: 100%;
 	height: auto !important;
+    max-height: 600px;
 }
 
 @media screen and ( max-width: 600px ){


### PR DESCRIPTION
Set max-height to 600px for images in the richtext class to prevent oversized
images from breaking the layout.