### PR TITLE
Fix blog post image sizing and service slug generation

### DIFF
--- a/app/blog/templates/blog/blog_base.html
+++ b/app/blog/templates/blog/blog_base.html
@@ -53,8 +53,8 @@
         <div class="col s12">
             {% for post in posts %}
             <div class="post d-flex">
-                <div class="image">
-                    <img src="{{post.image.url}}" alt="{{post}}" height="100%" width="100%">
+                <div >
+                    <img src="{{post.image.url}}" alt="{{post}}" height="400" width="100%">
                 </div>
                 <div class="content p-2">
                     <a class="undecorated text-secondary m-tb-20" href="{% url 'blog:post_detail' post.slug %}">

--- a/app/index/models/services.py
+++ b/app/index/models/services.py
@@ -24,7 +24,7 @@ class Service(models.Model):
         value = self.title
         slug_candidate = slug_original = slugify(value, allow_unicode=True)
         for i in itertools.count(1):
-            if not self.objects.filter(slug=slug_candidate).exists():
+            if not Service.objects.filter(slug=slug_candidate).exists():
                 break
             slug_candidate = '{}-{}'.format(slug_original, i)
         self.slug = slug_candidate


### PR DESCRIPTION
- Set fixed height and width for blog post images to ensure consistent sizing
- Fix bug in service slug generation where `self.objects` was used instead of `Service.objects`