### PR TITLE
Add ModelAdmin classes for Visa and Service models

### DIFF
--- a/app/index/admin.py
+++ b/app/index/admin.py
@@ -8,10 +8,14 @@ class CarouselItemAdmin(admin.ModelAdmin):
     list_display = ['html_stripped']
 
 
-admin.site.register(Action)
-admin.site.register(Visa)
+@admin.register(Visa)
+class ServiceAdmin(admin.ModelAdmin):
+    exclude = ['slug']
 
 
 @admin.register(Service)
 class ServiceAdmin(admin.ModelAdmin):
     exclude = ['slug']
+
+
+admin.site.register(Action)


### PR DESCRIPTION
- Create a ModelAdmin class for the Visa model
- Move the ServiceAdmin class registration to the class definition using the @admin.register decorator
- Exclude the 'slug' field from the admin forms for both Visa and Service models
- Remove the individual registration for the Service model as it's now handled by the @admin.register decorator