### PR TITLE
Fix avatar display in About page

### DIFF
--- a/app/about/static/css/about/index.css
+++ b/app/about/static/css/about/index.css
@@ -148,6 +148,12 @@
     cursor: pointer;
 }
 
+.avatar {
+    height: 100px;
+    width: auto;
+    object-fit: contain;
+}
+
 .content ul:not(.fa-ul)>li {
     list-style-type: initial !important;
     margin-left: 20px;

--- a/app/about/templates/about/index.html
+++ b/app/about/templates/about/index.html
@@ -115,7 +115,12 @@
                 <div class="people-grid">
                     {% for staff in staff %}
                     <div class="person">
-                        <img src="{{ staff.staff.avatar.url }}" height="100%" width="100%">
+                        {% if staff.staff.avatar %}
+                        <img src="{{ staff.staff.avatar.url }}" class="avatar">
+                        {% else %}
+                        <img src="{% static 'images/common/user.png' %}" class="avatar">
+                        {% endif %}
+
                         <div class="prof ps-2">
                             <h6><b>{{staff.staff.get_full_name}}</b></h6>
                             <p class="m-0">{{staff.role}}</p>

--- a/app/shortlist/presentation/views/openings.py
+++ b/app/shortlist/presentation/views/openings.py
@@ -13,10 +13,10 @@ class OpeningsView(ListView):
     paginate_by = 10
 
     def get(self, request, *args, **kwargs):
-        sort_term = self.request.GET.get('sort')
+        sort_term = self.request.GET.get('sort', None)
         if sort_term:
             self.request.session['sort'] = sort_term
-        search_term = self.request.GET.get('search')
+        search_term = self.request.GET.get('search', None)
         if search_term:
             self.request.session['search'] = search_term
         return super().get(request, *args, **kwargs)
@@ -27,6 +27,7 @@ class OpeningsView(ListView):
         if sort_term:
             industry = Industry.objects.get(pk=int(sort_term))
             queryset = queryset.filter(industry=industry)
+
         search_fields = \
             SearchVector('industry__title') \
             + SearchVector('industry__description') \

--- a/app/shortlist/templates/shortlist/openings.html
+++ b/app/shortlist/templates/shortlist/openings.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="{% static 'css/common/inputs.css' %}" />
 {% endblock %}
 {% block content %}
-<div class="container htmx-parent d-flex flex-column h-100" id="htmx-parent">
+<div class="container htmx-parent d-flex flex-column" id="htmx-parent">
     {% include 'shortlist/partials/openings.html' %}
 </div>
 {% endblock %}

--- a/app/shortlist/templates/shortlist/partials/openings.html
+++ b/app/shortlist/templates/shortlist/partials/openings.html
@@ -1,6 +1,7 @@
 {% load humanize %}
 {% load i18n %}
 {% load shortlist_extras %}
+
 <div class="row align-items-md-stretch d-flex flex-column h-100">
     <div class="col-md-12">
         <div class="h-100 p-5 bg-body-tertiary border rounded-3">
@@ -33,8 +34,9 @@
                                     <option {% if not request.session.sort %}selected{% endif %}>Filter by Industry
                                     </option>
                                     {% for industry in industries %}
-                                    <option
-                                        value="{{industry.pk}}" {% if request.session.sort|stringformat:"s" == industry.pk|stringformat:"s" %}selected{% endif %}>
+                                    <option value="{{industry.pk}}" {% if
+                                        request.session.sort|stringformat:"s"==industry.pk|stringformat:"s" %}selected{%
+                                        endif %}>
                                         {{industry}}
                                     </option>
                                     {% endfor %}
@@ -45,8 +47,8 @@
                             {% if request.session.sort %}
                             <form method="get" class="me-2" style="min-height: 100%;">
                                 <button class="btn btn-primary" type="button"
-                                    hx-get="{% url 'shortlist:clear_filters' filter_param='sort' next=request.path %}" hx-trigger="click"
-                                    style="min-height: 100%; height: 100% !important;">
+                                    hx-get="{% url 'shortlist:clear_filters' filter_param='sort' next=request.path %}"
+                                    hx-trigger="click" style="min-height: 100%; height: 100% !important;">
                                     <i class="fa-solid fa-xmark" title="clear sort"></i>
                                 </button>
                             </form>
@@ -82,7 +84,10 @@
             </div>
         </div>
 
+
+
         {% if paginator.count > 0 %}
+
         <div class="row content-row">
             <div class="col s12">
                 <table class="striped responsive-table">
@@ -135,7 +140,8 @@
         </div>
         {% else %}
         {% if request.session.search or request.session.sort %}
-        <h6><strong>We do not have the filtered openings at the moment. Please clear your filters or try searching with another keyword.</strong></h6>
+        <h6><strong>We do not have the filtered openings at the moment. Please clear your filters or try searching with
+                another keyword.</strong></h6>
         {% else %}
         <h6><strong>We do not have openings at the moment</strong></h6>
         {% endif %}


### PR DESCRIPTION
- Set fixed height and auto width for avatar images
- Use a default avatar image if staff member doesn't have one
- Adjust CSS to ensure proper sizing and object-fit for avatars

This improves the consistency and appearance of staff avatars on the About page, ensuring a cleaner layout even when avatar images are missing.